### PR TITLE
Chore: Typos fixed in multiple files

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -106,7 +106,7 @@
   - [Advance Level](interview-questions/advance-level.md)
 - [Design Patterns](design-patterns/README.md)
   - [Creational Patterns](design-patterns/creational-patterns.md)
-  - [Structual Level](design-patterns/structural-patterns.md)
+  - [Structural Level](design-patterns/structural-patterns.md)
   - [Behavioral Level](design-patterns/behavioral-patterns.md)
 - [References](References.md)
 - [Resources](resources.md)

--- a/en/arrays/for-each.md
+++ b/en/arrays/for-each.md
@@ -42,5 +42,5 @@ numbers.forEach(number => console.log(number * 2));
 The `forEach` method does not modify the original array. It simply iterates over the elements of the array and executes the provided function for each element.
 
 {% hint style="warning" %}
-The `forEach()` method is not executed for the empty statment.
+The `forEach()` method is not executed for the empty statement.
 {% endhint %}

--- a/en/arrays/join.md
+++ b/en/arrays/join.md
@@ -1,7 +1,7 @@
 ---
 chapter: 6
 pageNumber: 43
-description: The join method turns the array in a string an joins it all together without modifiying the original array.  
+description: The join method turns the array in a string an joins it all together without modifying the original array.  
 ---
 # Join
 

--- a/en/arrays/length.md
+++ b/en/arrays/length.md
@@ -1,7 +1,8 @@
+
 ---
 chapter: 6
 pageNumber: 44
-description: Arrays hava a property called length that measures the length of an array. 
+description: Arrays have a property called length that measures the length of an array. 
 ---
 # Length
 

--- a/en/arrays/unshift.md
+++ b/en/arrays/unshift.md
@@ -1,7 +1,7 @@
 ---
 chapter: 6
 pageNumber: 38 
-description:  To add an element at the begining of an array we can use the unshift method. It modifies the original array and return the new array length.
+description:  To add an element at the beginning of an array we can use the unshift method. It modifies the original array and return the new array length.
 ---
 # Unshift
 

--- a/en/browser-object-model-bom/cookies.md
+++ b/en/browser-object-model-bom/cookies.md
@@ -18,19 +18,19 @@ book = Learn Javascript
 The `document.cookie` property is used to create, read and delete cookies. Creating cookie is pretty easy you need to provide the name and value
 
 ```javascript
-document.cookie = "book=Learn Javacript";
+document.cookie = "book=Learn Javascript";
 ```
 
 By default, a cookie gets deleted when the browser is closed. To make it persistent, we need to specify the expiry date (in UTC time).
 
 ```javascript
-document.cookie = "book=Learn Javacript; expires=Fri, 08 Jan 2022 12:00:00 UTC";
+document.cookie = "book=Learn Javascript; expires=Fri, 08 Jan 2022 12:00:00 UTC";
 ```
 
 We can add a parameter to tell which path the cookie belongs to. By default, the cookie belongs to the current page.
 
 ```javascript
-document.cookie = "book=Learn Javacript; expires=Fri, 08 Jan 2022 12:00:00 UTC; path=/";
+document.cookie = "book=Learn Javascript; expires=Fri, 08 Jan 2022 12:00:00 UTC; path=/";
 ```
 
 Here is a simple example of a cookie.
@@ -39,6 +39,6 @@ Here is a simple example of a cookie.
 let cookies = document.cookie;
 // a simple way to reterive all cookie.
 
-document.cookie = "book=Learn Javacript; expires=Fri, 08 Jan 2022 12:00:00 UTC; path=/";
+document.cookie = "book=Learn Javascript; expires=Fri, 08 Jan 2022 12:00:00 UTC; path=/";
 // setting up a cookie
 ```

--- a/en/browser-object-model-bom/history.md
+++ b/en/browser-object-model-bom/history.md
@@ -16,7 +16,7 @@ window.history
 history
 ```
 
-To navigate  between the different history stack we can use   `go()` , `foward()` and  `back()`methods of **history** object.  
+To navigate  between the different history stack we can use   `go()` , `forward()` and  `back()`methods of **history** object.  
 
 1. **go\(\)**: It is used to navigate the specific URL of the history stack.
 

--- a/en/miscellaneous/README.md
+++ b/en/miscellaneous/README.md
@@ -7,7 +7,7 @@ pageNumber: 92
 # Chapter 19
 # Miscellaneous
 
-In this chapter we will be discussing various topics that will come accross through while writing code. The topics are listed below:
+In this chapter we will be discussing various topics that will come across through while writing code. The topics are listed below:
 
 * [Template Literals](./template-literals.md)
 * [Hoisting](./hoisting.md)

--- a/en/objects/delete.md
+++ b/en/objects/delete.md
@@ -23,7 +23,7 @@ child.age = 8;
 
 delete child.age;
 
-/* Remove age property from child, revealing the age of the prototype, because then it is not overriden. */
+/* Remove age property from child, revealing the age of the prototype, because then it is not overridden. */
 
 let prototypeAge = child.age;
 // 26, because child does not have its own age property.

--- a/en/objects/properties.md
+++ b/en/objects/properties.md
@@ -41,5 +41,5 @@ The following example shows how to **add** a new property **or change** an exist
 language.newProperty = "new value";
 // Now the object has a new property. If the property already exists, its value will be replaced.
 language["newProperty"] = "changed value";
-// Once again, you can access properties both ways. The first one (dot notation) is recomended.
+// Once again, you can access properties both ways. The first one (dot notation) is recommended.
 ```

--- a/en/regular-expression.md
+++ b/en/regular-expression.md
@@ -56,7 +56,7 @@ _Metacharacters_ are special character that has special meaning in the regular e
 | `\D`          | Match any non digiti character                                   |
 | `\s`          | Match a whitespace character (spaces, tabs etc)                  |
 | `\S`          | Match a non whitespace character                                 |
-| `\b`          | Match at the begining / end of a word                            |
+| `\b`          | Match at the beginning / end of a word                            |
 | `\B`          | Match but not at the begining / end of a word                    |
 | `\0`          | Match a `NULL` character                                         |
 |  `\n`             | Match a new line character                                       |

--- a/en/strings/README.md
+++ b/en/strings/README.md
@@ -26,8 +26,8 @@ String indexes are zero-based, meaning that starting position of the first chara
 | `endsWith()`         | Checks if a string ends with a specified value                                         |
 | `fromCharCode()`     | Returns Unicode values as characters                                                   |
 | `includes()`         | Checks if a string contains with a specified value                                     |
-| `indexOf()`          | Returns the index of its first occurance                                               |
-| `lastIndexOf()`      | Returns the index of its last occurance                                                |
+| `indexOf()`          | Returns the index of its first occurrence                                               |
+| `lastIndexOf()`      | Returns the index of its last occurrence                                                |
 | `length`             | Returns the length of the string                                                       |
 | `localeCompare()`    | Compares two strings with locale                                                       |
 | `match()`            | Matches a string against a value or regular expression                                 |
@@ -37,7 +37,7 @@ String indexes are zero-based, meaning that starting position of the first chara
 | `search()`           | Returns an index based on a string's match against a value or regular expression       |
 | `slice()`            | Returns a string containing part of a string                                           |
 | `split()`            | Splits string into array of substrings                                                 |
-| `startsWith()`       | Checks strings begining against specifed character                                     |
+| `startsWith()`       | Checks strings beginning against specified character                                     |
 | `substr()`           | Extracts part of string, from start index                                              |
 | `substring()`        | Extracts part of string, between two indices                                           |
 | `toLocalLowerCase()` | Returns string with lowercase characters using host's locale                           |


### PR DESCRIPTION
This pull request fix the typo that has been seen in multiple files.
```
Structual > Structural
statment > statement
modifiying > modifiying
hava > have
begining > beginning
Javacript > Javascript
recomended > recommended
```