### PR TITLE
fix: resolve critical lodash vulnerabilities (transitive via gitbook-plugin-sharing)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "overrides": {
+    "lodash": "^4.17.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   },
   "overrides": {
     "lodash": "^4.17.21"
+  },
+  "resolutions": {
+    "lodash": "^4.17.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     }
   },
   "overrides": {
-    "lodash": "^4.17.21"
+    "gitbook-plugin-sharing": {
+      "lodash": "4.17.21"
+    }
   },
   "resolutions": {
     "lodash": "^4.17.21"


### PR DESCRIPTION
## Description
This PR addresses several critical vulnerabilities identified in `lodash` (≤ 4.17.20), which is brought in as a transitive dependency via `gitbook-plugin-sharing`. 

Since the plugin is currently unmaintained and hasn't updated its dependencies, I have implemented an `overrides` block in `package.json` to force `lodash` to version `^4.17.21`.

## Related Issues
- Fixes #335
- Addresses: GHSA-fvqr-27wr-82fm, GHSA-35jh-r3h4-6jhm, GHSA-4xc9-xhrj-v574

## Changes
- Updated `package.json` with `npm overrides`.

## Verification
- Ran `npm audit` locally; critical vulnerabilities related to lodash are now resolved.
- Verified that GitBook still builds correctly with the overridden version.